### PR TITLE
Vendor-assistant metering and JetBrains coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 *"I feel nervous when I have subscription left over. That just means I haven't maximized my token throughput."*
 <br>Andrej Karpathy, [No Priors](https://podscripts.co/podcasts/no-priors-artificial-intelligence-technology-startups/andrej-karpathy-on-code-agents-autoresearch-and-the-loopy-era-of-ai) (2026)
 
-As of 2026-07: 172 entries across five areas, 8 practices, 10 concepts, 8 claims, and 7 copy-paste setups.
+As of 2026-07: 177 entries across five areas, 8 practices, 10 concepts, 8 claims, and 7 copy-paste setups.
 
 ## Contents
 
@@ -173,6 +173,7 @@ Each entry ends with a kind badge: ![tool: MIT](https://img.shields.io/badge/too
 ### Allocation Chargeback
 
 - [CloudZero](https://www.cloudzero.com/blog/ai-cost-optimization-at-scale/) - An established commercial cloud and AI cost-intelligence / FinOps platform that brands itself 'The AI ROI Company'. ![co](https://img.shields.io/badge/co-555?style=flat-square)
+- [JetBrains AI moves business plans from monthly licenses to 12-month credits](https://blog.jetbrains.com/blog/2026/07/07/jetbrains-ai-for-teams-and-organizations-from-fragmented-ai-usage-to-coordinated-software-development/) - JetBrains is moving business AI from monthly per-seat licenses to 12-month reallocatable credits plus a governance dashboard; personal Pro/Ultimate prices are…
 - [Mavvrik (fmr. DigitalEx)](https://www.mavvrik.ai/press-releases/mavvrik-unveils-full-stack-ai-cost-governance/) - Mavvrik is an AI/hybrid-infrastructure cost governance and FinOps platform, rebranded from DigitalEx in February 2025. ![co](https://img.shields.io/badge/co-555?style=flat-square)
 - [Pay-i](https://docs.pay-i.com/) - An SDK-based GenAI cost-observability platform that tracks token-level spend per call and rolls it up into cost-center allocation across orgs and apps. ![co](https://img.shields.io/badge/co-555?style=flat-square)
 
@@ -219,7 +220,7 @@ Each entry ends with a kind badge: ![tool: MIT](https://img.shields.io/badge/too
 ### Buyer Incentives
 
 - [Claude "subscription arbitrage" and its (announced, then paused) end](https://zed.dev/blog/anthropic-subscription-changes) - Users route agentic workloads worth far more than a subscription's price through cheap Pro/Max plans; Anthropic tried to close this, then paused the fix.
-- [Coding-agent native spend controls (2026)](https://cursor.com/changelog/05-04-26) - Within six weeks in 2026, Cursor, GitHub Copilot, and OpenAI each shipped native admin spend controls: budget caps, credit metering, usage dashboards.
+- [Coding-agent native spend controls (2026)](https://cursor.com/changelog/05-04-26) - Within six weeks in 2026, Cursor, GitHub Copilot, and OpenAI each shipped native admin spend controls: budget caps, credit metering, usage dashboards. (also: [GitHub Copilot](https://github.blog/news-insights/company-news/github-copilot-is-moving-to-usage-based-billing/) · [OpenAI](https://openai.com/index/chatgpt-enterprise-spend-controls/))
 - [GitHub Copilot metered-billing bill-shock - the demand-side reaction ("tokenpocalypse")](https://news.ycombinator.com/item?id=47923357) - GitHub's move from flat-rate Copilot plans to metered AI Credits exposed agentic workflows' true per-token cost and triggered a mass bill-shock backlash.
 - [Lanai](https://www.prnewswire.com/news-releases/lanai-launches-ai--work-operating-system-to-help-enterprises-close-the-ai-accountability-gap-302743892.html) - Lanai's AI @ Work platform discovers every sanctioned and shadow AI workflow across an org and maps its token spend to the KPIs it actually drives. ![co](https://img.shields.io/badge/co-555?style=flat-square)
 - [State of FinOps 2026 - AI spend management is now the norm](https://data.finops.org/) - This is the FinOps Foundation's sixth annual State of FinOps survey, the practitioner census of how organizations manage cloud and AI spend. ![report](https://img.shields.io/badge/report-555?style=flat-square)
@@ -228,6 +229,7 @@ Each entry ends with a kind badge: ![tool: MIT](https://img.shields.io/badge/too
 
 ### Compression Efficacy
 
+- [JetBrains independently measured two token-saving skills against their own claims](https://blog.jetbrains.com/ai/2026/07/rtk-claude-code-token-savings/) - JetBrains independently A/B-tested two token-saving skills: rtk ran +7.6% more expensive at low effort (claimed 60-90% cut), Caveman saved ~8.5% (claimed 65%). (also: [Caveman A/B post](https://blog.jetbrains.com/ai/2026/07/speak-to-ai-agents-like-cavemen-tosave-tokens/)) ![bench](https://img.shields.io/badge/bench-555?style=flat-square)
 - [Token-saving plugins are mostly a stupid idea (Tura benchmark)](https://turaai.net/blog#token-saving-plugins-are-mostly-stupid-idea) - A benchmark of token-saving plugins found one actively worse than none: cost up 7.2%, tokens up 13.2%, because it broke an already-cached prompt prefix.
 
 ### Consolidation
@@ -255,16 +257,18 @@ Each entry ends with a kind badge: ![tool: MIT](https://img.shields.io/badge/too
 - [Kimi K2.6/K2.7-Code and GLM-5.2 official API pricing](https://platform.kimi.ai/docs/pricing/chat-k27-code) - Kimi K2.7-Code ($0.95/$4.00 per million tokens) and GLM-5.2 ($1.40/$4.40) both undercut Claude Sonnet 5 and GPT-5.5 on raw price by 2-5x.
 - [Local / open-model economics for coding - state of the field (2026)](https://huggingface.co/Qwen/Qwen3.6-27B) - Open-weight coding models now score 77-81% on SWE-bench Verified, within a few points of closed frontier models, reshaping self-host-vs-API math.
 - [OckBench - measuring token efficiency / verbosity of LLM reasoning](https://arxiv.org/abs/2511.05722) - OckBench answers a specific tokenomics question: which model burns the most tokens for the same answer? ![paper](https://img.shields.io/badge/paper-555?style=flat-square)
-- [Reasoning-token billing across providers - the hidden output multiplier](https://developers.openai.com/api/docs/guides/reasoning) - Every major AI provider bills a model's hidden reasoning tokens at the most expensive output rate, without ever returning them to the caller.
+- [Reasoning-token billing across providers - the hidden output multiplier](https://developers.openai.com/api/docs/guides/reasoning) - Every major AI provider bills a model's hidden reasoning tokens at the most expensive output rate, without ever returning them to the caller. (also: [Google](https://ai.google.dev/gemini-api/docs/pricing) · [DeepSeek](https://api-docs.deepseek.com/guides/reasoning_model))
 - [Reasoning-token consumption behavior - length ≠ effort, and verbosity is a separate lever](https://arxiv.org/abs/2602.13517) - Chain-of-thought can burn about 258 tokens on problems a direct answer solves in 15 (roughly 17x overhead), and simple agentic steps trigger it by accident. ![paper](https://img.shields.io/badge/paper-555?style=flat-square)
 
 ### Pricing Models
 
-- [Batch / Priority / Flex service tiers - the scheduling axis of token pricing (clustered, cross-vendor)](https://platform.claude.com/docs/en/docs/build-with-claude/batch-processing) - Every major LLM vendor sells the same lever, trading latency for price via async batch scheduling, with Anthropic, OpenAI, and Google all near 50% off.
+- [Batch / Priority / Flex service tiers - the scheduling axis of token pricing (clustered, cross-vendor)](https://platform.claude.com/docs/en/docs/build-with-claude/batch-processing) - Every major LLM vendor sells the same lever, trading latency for price via async batch scheduling, with Anthropic, OpenAI, and Google all near 50% off. (also: [OpenAI](https://developers.openai.com/api/docs/pricing) · [Google](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/partner-models/claude/batch))
 - [Bessemer - the AI pricing & monetization playbook (seat → usage → outcome)](https://www.bvp.com/atlas/the-ai-pricing-and-monetization-playbook) - Bessemer's playbook argues AI pricing is shifting from per-seat to consumption/outcome-based, citing Intercom's $0.99-per-resolved-ticket model.
 - [Cached-input discounts - the ~90%-off lever behind cache-accounting](https://platform.claude.com/docs/en/build-with-claude/prompt-caching) - Cache-read pricing discounts input tokens by about 90%: the biggest lever on an agentic bill, since input is roughly 85% of session cost.
 - [ChatGPT subscription tiers and Codex CLI bundling/pricing (2026)](https://developers.openai.com/codex/pricing) - OpenAI bundles Codex CLI into every ChatGPT tier from Free through the new $100/mo Pro plan, differing only by rate-limit multiplier.
 - [ChatGPT workspace-agent credit billing (effective July 6, 2026)](https://help.openai.com/en/articles/11481834-chatgpt-rate-card) - OpenAI ended the free preview for agent runs invoked inside ChatGPT Business, Enterprise, Edu, and Teachers on 2026-07-06.
+- [Cursor charges by tokens, split into first-party and third-party pools](https://cursor.com/docs/account/pricing) - Cursor meters by tokens per million (input/output/cache-write/cache-read), split into a first-party pool and a third-party API pool, with a $0.25/M Teams… (also: [Teams pricing blog](https://cursor.com/blog/teams-pricing-june-2026))
+- [Devin's Agent Compute Unit has no published definition of what it meters](https://docs.devin.ai/admin/billing/enterprise) - Devin bills Enterprise usage in Agent Compute Units, but no official doc defines what an ACU measures (not tokens, seconds, or calls); the opacity itself is the…
 - [Fable 5 leaves subscription inclusion - frontier tier moves to usage-credit metering (July 7 cliff)](https://www.anthropic.com/news/redeploying-fable-5) - Anthropic is moving Fable 5 off subscription-included access onto usage-credit metering, with the cliff date slipped twice, now set for 2026-07-20.
 - [Google AI Pro price and Gemini/Antigravity free-tier limits (2026)](https://gemini.google/subscriptions/) - Google AI Pro is confirmed at $19.99/month, beneath the $99.99 and $199.99 AI Ultra tiers giving higher rate limits on the Gemini API and Antigravity.
 - [GPT-5.6 family (Sol / Terra / Luna) - API pricing](https://developers.openai.com/api/docs/pricing) - OpenAI's GPT-5.6 family prices three tiers 2x apart: Sol at $5/$30 per million tokens, Terra at $2.50/$15, and Luna at $1/$6.
@@ -273,6 +277,7 @@ Each entry ends with a kind badge: ![tool: MIT](https://img.shields.io/badge/too
 - [LLM token pricing dimensions - the structure of a token bill](https://platform.claude.com/docs/en/about-claude/pricing) - This maps out how frontier LLM APIs meter and price tokens, read straight off the two largest providers' pricing pages, Anthropic and OpenAI.
 - [OpenAI is winding down the self-serve fine-tuning API and platform](https://developers.openai.com/api/docs/deprecations) - OpenAI is winding down self-serve fine-tuning because prompting got cheaper and more capable than fine-tuning for most uses, cutting off customers by 2027.
 - [Tokenization multiplicity & overcharging - the pay-per-token integrity problem](https://arxiv.org/abs/2506.06446) - Two academic papers show the same output can be billed a different token count depending on tokenization, and providers can be incentivized to inflate it. ![paper](https://img.shields.io/badge/paper-555?style=flat-square)
+- [Windsurf became Devin Desktop and switched credits to token-based quota](https://docs.devin.ai/desktop/accounts/quota) - Windsurf became Devin Desktop and in March 2026 swapped opaque per-model credit multipliers for token-based quota where free models cost nothing; a…
 
 ### Reliability Sla
 
@@ -314,7 +319,7 @@ Each entry ends with a kind badge: ![tool: MIT](https://img.shields.io/badge/too
 
 - [Anthropic bill anatomy - the whole-bill line-item taxonomy](https://platform.claude.com/docs/en/about-claude/pricing#code-execution-tool) - This is the canonical enumeration of every meter on a Claude API bill, read live from Anthropic's pricing page.
 - [TensorZero - cross-vendor token-count divergence ("stop comparing $/M tokens")](https://www.tensorzero.com/blog/stop-comparing-price-per-million-tokens-the-hidden-llm-api-costs/) - The same input can produce 2.65x more tokens on one tokenizer than another's: Claude Opus 4-7 runs 1.57x-2.65x more tokens than GPT-5.4 on the same content.
-- [Vision-token pricing formulas across the big three](https://platform.claude.com/docs/en/build-with-claude/vision) - Anthropic, OpenAI, and Google each convert an image into billed tokens with a different formula, so no single cross-vendor image-cost number exists.
+- [Vision-token pricing formulas across the big three](https://platform.claude.com/docs/en/build-with-claude/vision) - Anthropic, OpenAI, and Google each convert an image into billed tokens with a different formula, so no single cross-vendor image-cost number exists. (also: [OpenAI](https://developers.openai.com/api/docs/guides/images-vision) · [Google](https://ai.google.dev/gemini-api/docs/image-understanding))
 
 ### Harness Overhead
 

--- a/research/govern.md
+++ b/research/govern.md
@@ -7,6 +7,9 @@
 - [Mavvrik (fmr. DigitalEx)](https://www.mavvrik.ai/press-releases/mavvrik-unveils-full-stack-ai-cost-governance/) - Mavvrik is an AI/hybrid-infrastructure cost governance and FinOps platform, rebranded from DigitalEx in February 2025. ![co](https://img.shields.io/badge/co-555?style=flat-square)
 - [Pay-i](https://docs.pay-i.com/) - An SDK-based GenAI cost-observability platform that tracks token-level spend per call and rolls it up into cost-center allocation across orgs and apps. ![co](https://img.shields.io/badge/co-555?style=flat-square)
 
+### Reading
+- [JetBrains AI moves business plans from monthly licenses to 12-month credits](https://blog.jetbrains.com/blog/2026/07/07/jetbrains-ai-for-teams-and-organizations-from-fragmented-ai-usage-to-coordinated-software-development/) - JetBrains is moving business AI from monthly per-seat licenses to 12-month reallocatable credits plus a governance dashboard; personal Pro/Ultimate prices are…
+
 ## Anomaly Detection
 
 ### Research & Benchmarks

--- a/research/manifest.json
+++ b/research/manifest.json
@@ -126,6 +126,15 @@
     "super_area": "govern"
   },
   {
+    "title": "JetBrains AI moves business plans from monthly licenses to 12-month credits",
+    "url": "https://blog.jetbrains.com/blog/2026/07/07/jetbrains-ai-for-teams-and-organizations-from-fragmented-ai-usage-to-coordinated-software-development/",
+    "verified_on": "2026-07-20",
+    "stale_after": "2026-10-20",
+    "category": "allocation-chargeback",
+    "kind": "article",
+    "super_area": "govern"
+  },
+  {
     "title": "Kong AI Gateway",
     "url": "https://developer.konghq.com/ai-gateway/",
     "verified_on": "2026-07-02",
@@ -1028,8 +1037,8 @@
   {
     "title": "rtk - the context-compression genre's largest adoption anchor (reduction-only headline)",
     "url": "https://github.com/rtk-ai/rtk",
-    "verified_on": "2026-07-05",
-    "stale_after": "2026-10-05",
+    "verified_on": "2026-07-20",
+    "stale_after": "2026-10-20",
     "category": "context-engineering",
     "kind": "oss",
     "super_area": "optimize"
@@ -1287,6 +1296,24 @@
     "super_area": "understand"
   },
   {
+    "title": "Cursor charges by tokens, split into first-party and third-party pools",
+    "url": "https://cursor.com/docs/account/pricing",
+    "verified_on": "2026-07-20",
+    "stale_after": "2026-10-20",
+    "category": "pricing-models",
+    "kind": "article",
+    "super_area": "understand"
+  },
+  {
+    "title": "Devin's Agent Compute Unit has no published definition of what it meters",
+    "url": "https://docs.devin.ai/admin/billing/enterprise",
+    "verified_on": "2026-07-20",
+    "stale_after": "2026-10-20",
+    "category": "pricing-models",
+    "kind": "article",
+    "super_area": "understand"
+  },
+  {
     "title": "DORA 2025 - AI as amplifier, and the delivery-stability tension",
     "url": "https://dora.dev/insights/balancing-ai-tensions/",
     "verified_on": "2026-07-02",
@@ -1374,6 +1401,15 @@
     "stale_after": "2026-10-15",
     "category": "pricing-models",
     "kind": "article",
+    "super_area": "understand"
+  },
+  {
+    "title": "JetBrains independently measured two token-saving skills against their own claims",
+    "url": "https://blog.jetbrains.com/ai/2026/07/rtk-claude-code-token-savings/",
+    "verified_on": "2026-07-20",
+    "stale_after": "2026-10-20",
+    "category": "compression-efficacy",
+    "kind": "benchmark",
     "super_area": "understand"
   },
   {
@@ -1544,6 +1580,15 @@
     "verified_on": "2026-07-01",
     "stale_after": "2026-10-01",
     "category": "buyer-incentives",
+    "kind": "article",
+    "super_area": "understand"
+  },
+  {
+    "title": "Windsurf became Devin Desktop and switched credits to token-based quota",
+    "url": "https://docs.devin.ai/desktop/accounts/quota",
+    "verified_on": "2026-07-20",
+    "stale_after": "2026-10-20",
+    "category": "pricing-models",
     "kind": "article",
     "super_area": "understand"
   }

--- a/research/measure.md
+++ b/research/measure.md
@@ -32,7 +32,7 @@
 ### Reading
 - [Anthropic bill anatomy - the whole-bill line-item taxonomy](https://platform.claude.com/docs/en/about-claude/pricing#code-execution-tool) - This is the canonical enumeration of every meter on a Claude API bill, read live from Anthropic's pricing page.
 - [TensorZero - cross-vendor token-count divergence ("stop comparing $/M tokens")](https://www.tensorzero.com/blog/stop-comparing-price-per-million-tokens-the-hidden-llm-api-costs/) - The same input can produce 2.65x more tokens on one tokenizer than another's: Claude Opus 4-7 runs 1.57x-2.65x more tokens than GPT-5.4 on the same content.
-- [Vision-token pricing formulas across the big three](https://platform.claude.com/docs/en/build-with-claude/vision) - Anthropic, OpenAI, and Google each convert an image into billed tokens with a different formula, so no single cross-vendor image-cost number exists.
+- [Vision-token pricing formulas across the big three](https://platform.claude.com/docs/en/build-with-claude/vision) - Anthropic, OpenAI, and Google each convert an image into billed tokens with a different formula, so no single cross-vendor image-cost number exists. (also: [OpenAI](https://developers.openai.com/api/docs/guides/images-vision) · [Google](https://ai.google.dev/gemini-api/docs/image-understanding))
 
 ## Harness Overhead
 

--- a/research/understand.md
+++ b/research/understand.md
@@ -10,12 +10,15 @@
 
 ### Reading
 - [Claude "subscription arbitrage" and its (announced, then paused) end](https://zed.dev/blog/anthropic-subscription-changes) - Users route agentic workloads worth far more than a subscription's price through cheap Pro/Max plans; Anthropic tried to close this, then paused the fix.
-- [Coding-agent native spend controls (2026)](https://cursor.com/changelog/05-04-26) - Within six weeks in 2026, Cursor, GitHub Copilot, and OpenAI each shipped native admin spend controls: budget caps, credit metering, usage dashboards.
+- [Coding-agent native spend controls (2026)](https://cursor.com/changelog/05-04-26) - Within six weeks in 2026, Cursor, GitHub Copilot, and OpenAI each shipped native admin spend controls: budget caps, credit metering, usage dashboards. (also: [GitHub Copilot](https://github.blog/news-insights/company-news/github-copilot-is-moving-to-usage-based-billing/) · [OpenAI](https://openai.com/index/chatgpt-enterprise-spend-controls/))
 - [GitHub Copilot metered-billing bill-shock - the demand-side reaction ("tokenpocalypse")](https://news.ycombinator.com/item?id=47923357) - GitHub's move from flat-rate Copilot plans to metered AI Credits exposed agentic workflows' true per-token cost and triggered a mass bill-shock backlash.
 - [The "$47k Claude Code bill" - the anchor bill-shock anecdote and its mechanistic debunk](https://yusufhansacak.medium.com/the-47-000-agent-bill-what-the-viral-token-stories-get-wrong-7ee1cdd81e65) - A viral $47,000-in-90-days Claude Code bill story was debunked by a teardown pinning the real driver on quadratic context re-ingestion, not runaway use.
 - [Uber caps AI-coding spend at $1,500/mo per tool after burning its budget in ~4 months](https://techcrunch.com/2026/06/02/uber-caps-employee-ai-spending-after-blowing-through-budget-in-four-months/) - Uber capped AI-coding spend at $1,500 per employee per tool after burning its entire annual budget in roughly four months of encouraged maximal use.
 
 ## Compression Efficacy
+
+### Research & Benchmarks
+- [JetBrains independently measured two token-saving skills against their own claims](https://blog.jetbrains.com/ai/2026/07/rtk-claude-code-token-savings/) - JetBrains independently A/B-tested two token-saving skills: rtk ran +7.6% more expensive at low effort (claimed 60-90% cut), Caveman saved ~8.5% (claimed 65%). (also: [Caveman A/B post](https://blog.jetbrains.com/ai/2026/07/speak-to-ai-agents-like-cavemen-tosave-tokens/)) ![bench](https://img.shields.io/badge/bench-555?style=flat-square)
 
 ### Reading
 - [Token-saving plugins are mostly a stupid idea (Tura benchmark)](https://turaai.net/blog#token-saving-plugins-are-mostly-stupid-idea) - A benchmark of token-saving plugins found one actively worse than none: cost up 7.2%, tokens up 13.2%, because it broke an already-cached prompt prefix.
@@ -52,7 +55,7 @@
 - ["Qwen 3.6 27B is the sweet spot for local development" - Migdał / Quesma (first-party)](https://quesma.com/blog/qwen-36-is-awesome/) - Piotr Migdał's #1-on-Hacker-News essay argues Qwen3.6-27B (dense) is the first local model good enough for real coding instead of a metered cloud API.
 - [Kimi K2.6/K2.7-Code and GLM-5.2 official API pricing](https://platform.kimi.ai/docs/pricing/chat-k27-code) - Kimi K2.7-Code ($0.95/$4.00 per million tokens) and GLM-5.2 ($1.40/$4.40) both undercut Claude Sonnet 5 and GPT-5.5 on raw price by 2-5x.
 - [Local / open-model economics for coding - state of the field (2026)](https://huggingface.co/Qwen/Qwen3.6-27B) - Open-weight coding models now score 77-81% on SWE-bench Verified, within a few points of closed frontier models, reshaping self-host-vs-API math.
-- [Reasoning-token billing across providers - the hidden output multiplier](https://developers.openai.com/api/docs/guides/reasoning) - Every major AI provider bills a model's hidden reasoning tokens at the most expensive output rate, without ever returning them to the caller.
+- [Reasoning-token billing across providers - the hidden output multiplier](https://developers.openai.com/api/docs/guides/reasoning) - Every major AI provider bills a model's hidden reasoning tokens at the most expensive output rate, without ever returning them to the caller. (also: [Google](https://ai.google.dev/gemini-api/docs/pricing) · [DeepSeek](https://api-docs.deepseek.com/guides/reasoning_model))
 
 ## Pricing Models
 
@@ -60,11 +63,13 @@
 - [Tokenization multiplicity & overcharging - the pay-per-token integrity problem](https://arxiv.org/abs/2506.06446) - Two academic papers show the same output can be billed a different token count depending on tokenization, and providers can be incentivized to inflate it. ![paper](https://img.shields.io/badge/paper-555?style=flat-square)
 
 ### Reading
-- [Batch / Priority / Flex service tiers - the scheduling axis of token pricing (clustered, cross-vendor)](https://platform.claude.com/docs/en/docs/build-with-claude/batch-processing) - Every major LLM vendor sells the same lever, trading latency for price via async batch scheduling, with Anthropic, OpenAI, and Google all near 50% off.
+- [Batch / Priority / Flex service tiers - the scheduling axis of token pricing (clustered, cross-vendor)](https://platform.claude.com/docs/en/docs/build-with-claude/batch-processing) - Every major LLM vendor sells the same lever, trading latency for price via async batch scheduling, with Anthropic, OpenAI, and Google all near 50% off. (also: [OpenAI](https://developers.openai.com/api/docs/pricing) · [Google](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/partner-models/claude/batch))
 - [Bessemer - the AI pricing & monetization playbook (seat → usage → outcome)](https://www.bvp.com/atlas/the-ai-pricing-and-monetization-playbook) - Bessemer's playbook argues AI pricing is shifting from per-seat to consumption/outcome-based, citing Intercom's $0.99-per-resolved-ticket model.
 - [Cached-input discounts - the ~90%-off lever behind cache-accounting](https://platform.claude.com/docs/en/build-with-claude/prompt-caching) - Cache-read pricing discounts input tokens by about 90%: the biggest lever on an agentic bill, since input is roughly 85% of session cost.
 - [ChatGPT subscription tiers and Codex CLI bundling/pricing (2026)](https://developers.openai.com/codex/pricing) - OpenAI bundles Codex CLI into every ChatGPT tier from Free through the new $100/mo Pro plan, differing only by rate-limit multiplier.
 - [ChatGPT workspace-agent credit billing (effective July 6, 2026)](https://help.openai.com/en/articles/11481834-chatgpt-rate-card) - OpenAI ended the free preview for agent runs invoked inside ChatGPT Business, Enterprise, Edu, and Teachers on 2026-07-06.
+- [Cursor charges by tokens, split into first-party and third-party pools](https://cursor.com/docs/account/pricing) - Cursor meters by tokens per million (input/output/cache-write/cache-read), split into a first-party pool and a third-party API pool, with a $0.25/M Teams… (also: [Teams pricing blog](https://cursor.com/blog/teams-pricing-june-2026))
+- [Devin's Agent Compute Unit has no published definition of what it meters](https://docs.devin.ai/admin/billing/enterprise) - Devin bills Enterprise usage in Agent Compute Units, but no official doc defines what an ACU measures (not tokens, seconds, or calls); the opacity itself is the…
 - [Fable 5 leaves subscription inclusion - frontier tier moves to usage-credit metering (July 7 cliff)](https://www.anthropic.com/news/redeploying-fable-5) - Anthropic is moving Fable 5 off subscription-included access onto usage-credit metering, with the cliff date slipped twice, now set for 2026-07-20.
 - [Google AI Pro price and Gemini/Antigravity free-tier limits (2026)](https://gemini.google/subscriptions/) - Google AI Pro is confirmed at $19.99/month, beneath the $99.99 and $199.99 AI Ultra tiers giving higher rate limits on the Gemini API and Antigravity.
 - [GPT-5.6 family (Sol / Terra / Luna) - API pricing](https://developers.openai.com/api/docs/pricing) - OpenAI's GPT-5.6 family prices three tiers 2x apart: Sol at $5/$30 per million tokens, Terra at $2.50/$15, and Luna at $1/$6.
@@ -72,6 +77,7 @@
 - [LLM price decline + Jevons paradox - unit price crashes, total spend climbs](https://a16z.com/llmflation-llm-inference-cost/) - Per-token prices are falling roughly an order of magnitude per year, while total AI spend rises even faster.
 - [LLM token pricing dimensions - the structure of a token bill](https://platform.claude.com/docs/en/about-claude/pricing) - This maps out how frontier LLM APIs meter and price tokens, read straight off the two largest providers' pricing pages, Anthropic and OpenAI.
 - [OpenAI is winding down the self-serve fine-tuning API and platform](https://developers.openai.com/api/docs/deprecations) - OpenAI is winding down self-serve fine-tuning because prompting got cheaper and more capable than fine-tuning for most uses, cutting off customers by 2027.
+- [Windsurf became Devin Desktop and switched credits to token-based quota](https://docs.devin.ai/desktop/accounts/quota) - Windsurf became Devin Desktop and in March 2026 swapped opaque per-model credit multipliers for token-based quota where free models cost nothing; a…
 
 ## Reliability Sla
 

--- a/scripts/lint_readme.sh
+++ b/scripts/lint_readme.sh
@@ -12,7 +12,10 @@
 # syntax) still fails the build.
 set -uo pipefail
 
-WAIVED='remark-lint:awesome-list-item'
+# awesome-github's "valid git repository" check requires the checkout to be
+# on the default branch, so every PR branch fails it by construction; waive
+# that one message (not the whole rule) now that main is PR-only.
+WAIVED='remark-lint:awesome-list-item|Awesome list must reside in a valid git repository'
 
 out="$(npx --yes awesome-lint 2>&1)" || true
 errors="$(printf '%s\n' "$out" | grep '✖' | grep -v 'Linting' | grep -vE "$WAIVED" || true)"


### PR DESCRIPTION
Team-feedback round: coverage of how the assistant products themselves meter and optimize token usage.

## What's new (172 -> 177 entries)
- Cursor token metering: per-token pricing mechanics, dual usage pools, Teams surcharge
- Devin ACU metering opacity: no official page defines what an ACU measures; the opacity is the finding
- Windsurf / Devin Desktop: the March 2026 move from opaque credits to a token-based quota
- JetBrains AI credits: the business-model repackaging plus JetBrains Central governance
- JetBrains token-saving skill A/B tests: rtk (advertised 60-90% savings) measured more expensive than no skill at low effort; terse-prompting measured ~8.5% vs a claimed 65%

## Improvements
- Multi-vendor entries now carry secondary links, e.g. the spend-controls entry links Cursor, GitHub Copilot, and OpenAI instead of Cursor only
- Lint: awesome-lint's default-branch check waived by exact message so PR branches can pass CI (documented in scripts/lint_readme.sh)