### PR TITLE
Freshness rule for tools + lint CI on all markdown

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -18,10 +18,15 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@v2
         with:
+          # ampcode.com is alive (curl gets 200 over both HTTP/1.1 and HTTP/2)
+          # but lychee's HTTP/2 client errors against its server, reproduced
+          # locally with lychee 0.24.2 outside CI (checked 2026-07-25).
+          # Reported upstream: https://github.com/lycheeverse/lychee/issues/2264
           args: >-
             --no-progress
             --exclude "localhost"
             --exclude "127.0.0.1"
+            --exclude "ampcode.com"
             --max-retries 3
             --retry-wait-time 30
             --timeout 45

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,12 +3,16 @@ name: Lint
 on:
   pull_request:
     paths:
-      - "README.md"
+      - "**.md"
+      - "scripts/lint_readme.sh"
+      - "scripts/emdash-allowlist.txt"
   push:
     branches:
       - main
     paths:
-      - "README.md"
+      - "**.md"
+      - "scripts/lint_readme.sh"
+      - "scripts/emdash-allowlist.txt"
 
 jobs:
   awesome-lint:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,3 +43,8 @@ Every internal cross-reference is a plain relative markdown link. No wikilinks:
 Entries carry a `verified_on` date. CI flags entries that haven't been re-verified within our
 staleness thresholds (see `.github/workflows/staleness.yml`). A stale flag isn't necessarily
 wrong. It's a prompt to re-check.
+
+Tool entries additionally follow a maintenance rule: a tool whose repository has had no commit
+for more than 12 months gets flagged for review and dropped unless there is a stated reason to
+keep it (a finished, stable tool can earn an explicit exception). The last-commit badges on the
+list are the instrument of this rule, not decoration.


### PR DESCRIPTION
Part of #6 (reported by @wachulski) - makes the freshness discipline a stated rule, and closes a lint-coverage gap found while reviewing the CI.

## Changes

**CONTRIBUTING.md, Freshness section** - states the maintenance rule the last-commit badges already imply: a tool untouched for more than 12 months gets flagged for review and dropped unless there is a stated reason to keep it (finished, stable tools can earn an explicit exception). The badges are the instrument of the rule, not decoration.

**lint.yml triggers broadened** - the workflow only fired on `README.md` changes, but `scripts/lint_readme.sh` also enforces the em-dash ban across all tracked markdown. A PR touching only `practices/`, `concepts/` or `setups/` skipped the check entirely. Now any markdown change (plus the lint script and allowlist themselves) runs the gate.

`scripts/lint_readme.sh` passes locally.


**Also carried in this branch:** an `--exclude "ampcode.com"` added to the lychee args in `links.yml`. The site is alive (200 via curl over HTTP/1.1 and HTTP/2) but lychee itself fails against it with an HTTP/2 stream error, reproduced locally with lychee 0.24.2 outside CI, so it is a lychee-client incompatibility, not a dead link. Rationale sits in a comment next to the args; same commit on all open PRs, merges cleanly in any order.