### PR TITLE
Add project logo (token-economy theme)

### DIFF
--- a/.github/logo.svg
+++ b/.github/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" fill="none" role="img" aria-label="Awesome AI Tokenomics">
+  <circle cx="52" cy="52" r="36" stroke="#8FB4F2" stroke-width="11"></circle>
+  <path d="M78 78 L108 108" stroke="#2F6FE0" stroke-width="11" stroke-linecap="round" stroke-linejoin="round"></path>
+  <path d="M38 62 V44 M52 62 V34 M66 62 V52" stroke="#2F6FE0" stroke-width="11" stroke-linecap="round" stroke-linejoin="round"></path>
+</svg>

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -18,10 +18,15 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@v2
         with:
+          # ampcode.com is alive (curl gets 200 over both HTTP/1.1 and HTTP/2)
+          # but lychee's HTTP/2 client errors against its server, reproduced
+          # locally with lychee 0.24.2 outside CI (checked 2026-07-25).
+          # Reported upstream: https://github.com/lycheeverse/lychee/issues/2264
           args: >-
             --no-progress
             --exclude "localhost"
             --exclude "127.0.0.1"
+            --exclude "ampcode.com"
             --max-retries 3
             --retry-wait-time 30
             --timeout 45

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Awesome AI Tokenomics [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
+<img src=".github/logo.svg" align="right" width="110" alt="">
+
 > A map of what AI tokens actually cost, and where they're wasted vs. well spent.
 
 *"I feel nervous when I have subscription left over. That just means I haven't maximized my token throughput."*


### PR DESCRIPTION
Part of #6 (reported by @wachulski) - the manifesto encourages a project logo, and it lifts the list visually.

## Design

SVG at `.github/logo.svg`, right-aligned in the README header at 110px, next to the tagline: a magnifying glass over a bar chart - inspecting where tokens actually go, which is what this list is for. Brand blues, works on light and dark GitHub themes.

`scripts/lint_readme.sh` passes (the image sits after the H1, so awesome-lint heading rules are untouched).

**Also carried in this branch:** an `--exclude "ampcode.com"` added to the lychee args in `links.yml`. The site is alive (200 via curl over HTTP/1.1 and HTTP/2) but lychee itself fails against it with an HTTP/2 stream error, reproduced locally with lychee 0.24.2 outside CI - a lychee-client incompatibility, not a dead link, reported upstream as lycheeverse/lychee#2264. Same commit on all open PRs, merges cleanly in any order.