### PR TITLE
Add Related lists section

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A hybrid by design: a curated awesome list at the core, plus a field-guide layer
 - [Concepts](#concepts)
 - [Claims](#claims)
 - [Setups and skills](#setups-and-skills)
+- [Related lists](#related-lists)
 
 ## Where to start
 
@@ -387,6 +388,13 @@ Confidence-scored beliefs, clearly labeled as beliefs rather than facts, each wi
 ## Setups and skills
 
 Runnable, validated Claude Code and Codex configurations and skills for token-efficient agentic coding, each labeled with how it was validated. [Browse the setups](setups/README.md).
+
+## Related lists
+
+- [Awesome-LLM](https://github.com/Hannibal046/Awesome-LLM) - Curated papers, frameworks, and resources on large language models.
+- [Awesome-LLMOps](https://github.com/tensorchord/Awesome-LLMOps) - Tools and platforms for operating LLMs in production.
+- [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers) - A collection of Model Context Protocol servers.
+- [awesome-production-machine-learning](https://github.com/EthicalML/awesome-production-machine-learning) - Open-source libraries to deploy, monitor, version, and scale machine learning.
 
 ---
 


### PR DESCRIPTION
Adds a Related lists section at the end of the README (after Setups and skills, before the license footer), with a matching Contents entry.

Four neighboring curated lists, each verified against the GitHub API on 2026-07-28 as the canonical, unarchived repo:
- Hannibal046/Awesome-LLM (27,198 stars)
- tensorchord/Awesome-LLMOps (5,898 stars, pushed 2026-05-21; the InftyAI fork was checked and is not needed since the original is active)
- punkpeye/awesome-mcp-servers (91,469 stars)
- EthicalML/awesome-production-machine-learning (20,806 stars)

Descriptions are factual one-liners. scripts/lint_readme.sh passes (awesome-lint waivers unchanged, no em-dashes, no superlatives).