### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,19 @@
+cff-version: 1.2.0
+message: "If you cite this repository, please use the metadata from this file."
+title: "Awesome AI Tokenomics"
+type: dataset
+authors:
+  - name: "Quesma"
+    website: "https://quesma.com"
+repository-code: "https://github.com/QuesmaOrg/awesome-ai-tokenomics"
+url: "https://github.com/QuesmaOrg/awesome-ai-tokenomics"
+license: CC-BY-4.0
+abstract: "A map of what AI tokens actually cost, and where they're wasted vs. well spent: a curated list of tools, benchmarks, papers, and primary sources on AI token economics, with a field-guide layer of practices, concepts, and claims."
+keywords:
+  - ai
+  - tokenomics
+  - llm
+  - token-economics
+  - agentic-coding
+  - cost-optimization
+  - finops


### PR DESCRIPTION
Adds a CITATION.cff at the repo root so GitHub renders the "Cite this repository" button with APA and BibTeX export.

Choices:
- Entity author (Quesma), matching the README footer.
- type: dataset - the honest fit for a curated list (CFF only offers software or dataset).
- License field: CC-BY-4.0, covering the citable text content.
- No version or date-released fields - the repo has no tagged releases, and a hardcoded date would go stale. If we later adopt tagged releases plus Zenodo DOI archiving, those fields and a DOI identifier can be added then.

Validated against the CFF 1.2.0 schema with cffconvert.