### PR TITLE
Remove Tura token-saving-plugins benchmark entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,6 @@ Each entry ends with a kind badge: ![tool: MIT](https://img.shields.io/badge/too
 ### Compression Efficacy
 
 - [JetBrains independently measured two token-saving skills against their own claims](https://blog.jetbrains.com/ai/2026/07/rtk-claude-code-token-savings/) - JetBrains independently A/B-tested two token-saving skills: rtk ran +7.6% more expensive at low effort (claimed 60-90% cut), Caveman saved ~8.5% (claimed 65%). (also: [Caveman A/B post](https://blog.jetbrains.com/ai/2026/07/speak-to-ai-agents-like-cavemen-tosave-tokens/)) ![bench](https://img.shields.io/badge/bench-555?style=flat-square)
-- [Token-saving plugins are mostly a stupid idea (Tura benchmark)](https://turaai.net/blog#token-saving-plugins-are-mostly-stupid-idea) - A benchmark of token-saving plugins found one actively worse than none: cost up 7.2%, tokens up 13.2%, because it broke an already-cached prompt prefix.
 
 ### Consolidation
 

--- a/research/manifest.json
+++ b/research/manifest.json
@@ -1755,15 +1755,6 @@
     "super_area": "understand"
   },
   {
-    "title": "Token-saving plugins are mostly a stupid idea (Tura benchmark)",
-    "url": "https://turaai.net/blog#token-saving-plugins-are-mostly-stupid-idea",
-    "verified_on": "2026-07-17",
-    "stale_after": "2026-10-17",
-    "category": "compression-efficacy",
-    "kind": "article",
-    "super_area": "understand"
-  },
-  {
     "title": "Tokenization multiplicity & overcharging - the pay-per-token integrity problem",
     "url": "https://arxiv.org/abs/2506.06446",
     "verified_on": "2026-07-02",

--- a/research/understand.md
+++ b/research/understand.md
@@ -21,7 +21,6 @@
 - [JetBrains independently measured two token-saving skills against their own claims](https://blog.jetbrains.com/ai/2026/07/rtk-claude-code-token-savings/) - JetBrains independently A/B-tested two token-saving skills: rtk ran +7.6% more expensive at low effort (claimed 60-90% cut), Caveman saved ~8.5% (claimed 65%). (also: [Caveman A/B post](https://blog.jetbrains.com/ai/2026/07/speak-to-ai-agents-like-cavemen-tosave-tokens/)) ![bench](https://img.shields.io/badge/bench-555?style=flat-square)
 
 ### Reading
-- [Token-saving plugins are mostly a stupid idea (Tura benchmark)](https://turaai.net/blog#token-saving-plugins-are-mostly-stupid-idea) - A benchmark of token-saving plugins found one actively worse than none: cost up 7.2%, tokens up 13.2%, because it broke an already-cached prompt prefix.
 
 ## Consolidation
 


### PR DESCRIPTION
Removes the Tura benchmark entry from Compression Efficacy (README, research/understand.md, research/manifest.json).

Reasons, surfaced by rtk-community feedback and confirmed against the source:
- The benchmark is n=2 per arm on a single task; its own authors disclaim statistical significance, and within-arm cost variance (30.8-51.7%) exceeds the ~7% deltas it reports.
- Tura AI is itself a token-efficiency agent vendor benchmarking the genre it competes with, so the rtk-negative result is a competitor-reported number. The list entry carried neither disclosure.
- The lesson the entry taught (token cuts can raise cost by breaking the cached prefix) is already covered directly above by the JetBrains A/B study - 425 trials, disclosed method, p-values.
