### PR TITLE
README: drop stale entry-count line from intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ Every entry is a link with a one-line summary: what it does, and the number behi
 *"I feel nervous when I have subscription left over. That just means I haven't maximized my token throughput."*
 <br>Andrej Karpathy, [No Priors](https://podscripts.co/podcasts/no-priors-artificial-intelligence-technology-startups/andrej-karpathy-on-code-agents-autoresearch-and-the-loopy-era-of-ai) (2026)
 
-As of 2026-07: ~200 entries across five areas.
-
 **Topics:** [Caching](#caching) · [Compression](#compression) · [Context engineering](#context-engineering) · [Memory](#memory) · [Routing](#routing-model-selection) · [Multi-agent systems](#multi-agent-systems) · [Gateways](#gateways-and-proxies) · [Observability](#observability) · [Benchmarks](#benchmarks-evals) · [Cache accounting](#cache-accounting) · [Budgets](#budgets-caps) · [Pricing models](#pricing-models) · [Energy](#energy-carbon)
 
 ## Contents


### PR DESCRIPTION
Removes the "As of 2026-07: ~200 entries across five areas." line from the README intro.

The line was stale on both counts: the entry count drifts with every weekly sync, and the collection now spans far more than five areas.
