### PR TITLE
Add AICostBudget AI API Pricing Dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ Each entry ends with a kind badge: ![tool: MIT](https://img.shields.io/badge/too
 
 ### Pricing Models
 
-- [AICostBudget AI API Pricing Dataset](https://aicostbudget.com/en/datasets/ai-api-pricing) - Publishes source-linked AI API pricing records with normalized JSON and CSV exports.
+- [AICostBudget AI API Pricing Dataset](https://aicostbudget.com/en/datasets/ai-api-pricing) - Publishes source-linked AI API pricing records with normalized JSON and CSV exports. ![data](https://img.shields.io/badge/data-555?style=flat-square)
 - [Batch / Priority / Flex service tiers - the scheduling axis of token pricing (clustered, cross-vendor)](https://platform.claude.com/docs/en/docs/build-with-claude/batch-processing) - Every major LLM vendor sells the same lever, trading latency for price via async batch scheduling, with Anthropic, OpenAI, and Google all near 50% off. (also: [OpenAI](https://developers.openai.com/api/docs/pricing) · [Google](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/partner-models/claude/batch))
 - [Bessemer - the AI pricing & monetization playbook (seat → usage → outcome)](https://www.bvp.com/atlas/the-ai-pricing-and-monetization-playbook) - Bessemer's playbook argues AI pricing is shifting from per-seat to consumption/outcome-based, citing Intercom's $0.99-per-resolved-ticket model.
 - [Cached-input discounts - the ~90%-off lever behind cache-accounting](https://platform.claude.com/docs/en/build-with-claude/prompt-caching) - Cache-read pricing discounts input tokens by about 90%: the biggest lever on an agentic bill, since input is roughly 85% of session cost.

--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ Each entry ends with a kind badge: ![tool: MIT](https://img.shields.io/badge/too
 
 ### Pricing Models
 
+- [AICostBudget AI API Pricing Dataset](https://aicostbudget.com/en/datasets/ai-api-pricing) - Publishes source-linked AI API pricing records with normalized JSON and CSV exports.
 - [Batch / Priority / Flex service tiers - the scheduling axis of token pricing (clustered, cross-vendor)](https://platform.claude.com/docs/en/docs/build-with-claude/batch-processing) - Every major LLM vendor sells the same lever, trading latency for price via async batch scheduling, with Anthropic, OpenAI, and Google all near 50% off. (also: [OpenAI](https://developers.openai.com/api/docs/pricing) · [Google](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/partner-models/claude/batch))
 - [Bessemer - the AI pricing & monetization playbook (seat → usage → outcome)](https://www.bvp.com/atlas/the-ai-pricing-and-monetization-playbook) - Bessemer's playbook argues AI pricing is shifting from per-seat to consumption/outcome-based, citing Intercom's $0.99-per-resolved-ticket model.
 - [Cached-input discounts - the ~90%-off lever behind cache-accounting](https://platform.claude.com/docs/en/build-with-claude/prompt-caching) - Cache-read pricing discounts input tokens by about 90%: the biggest lever on an agentic bill, since input is roughly 85% of session cost.

--- a/research/manifest.json
+++ b/research/manifest.json
@@ -1530,6 +1530,15 @@
     "super_area": "optimize"
   },
   {
+    "title": "AICostBudget AI API Pricing Dataset",
+    "url": "https://aicostbudget.com/en/datasets/ai-api-pricing",
+    "verified_on": "2026-08-11",
+    "stale_after": "2026-11-09",
+    "category": "pricing-models",
+    "kind": "dataset",
+    "super_area": "understand"
+  },
+  {
     "title": "Aider - an OSS coding CLI that meters its own dollar cost",
     "url": "https://github.com/Aider-AI/aider",
     "verified_on": "2026-07-26",

--- a/research/understand.md
+++ b/research/understand.md
@@ -62,6 +62,7 @@
 ## Pricing Models
 
 ### Tools
+- [AICostBudget AI API Pricing Dataset](https://aicostbudget.com/en/datasets/ai-api-pricing) - Publishes source-linked AI API pricing records with normalized JSON and CSV exports.
 - [Doubleword](https://doubleword.ai) - Sells async and batch inference on open models, publishing a cost-per-1B-tokens table that holds capability constant using the third-party Artificial Analysis index. ![co](https://img.shields.io/badge/co-555?style=flat-square)
 
 ### Research & Benchmarks

--- a/research/understand.md
+++ b/research/understand.md
@@ -62,10 +62,10 @@
 ## Pricing Models
 
 ### Tools
-- [AICostBudget AI API Pricing Dataset](https://aicostbudget.com/en/datasets/ai-api-pricing) - Publishes source-linked AI API pricing records with normalized JSON and CSV exports.
 - [Doubleword](https://doubleword.ai) - Sells async and batch inference on open models, publishing a cost-per-1B-tokens table that holds capability constant using the third-party Artificial Analysis index. ![co](https://img.shields.io/badge/co-555?style=flat-square)
 
 ### Research & Benchmarks
+- [AICostBudget AI API Pricing Dataset](https://aicostbudget.com/en/datasets/ai-api-pricing) - Publishes source-linked AI API pricing records with normalized JSON and CSV exports. ![data](https://img.shields.io/badge/data-555?style=flat-square)
 - [Tokenization multiplicity & overcharging - the pay-per-token integrity problem](https://arxiv.org/abs/2506.06446) - Two academic papers show the same output can be billed a different token count depending on tokenization, and providers can be incentivized to inflate it. ![paper](https://img.shields.io/badge/paper-555?style=flat-square)
 
 ### Reading


### PR DESCRIPTION
Adds AICostBudget AI API Pricing Dataset to `Understand > Pricing Models`.

The public dataset provides normalized JSON and CSV pricing records across AI model providers. Records include official source URLs and verification dates, and the linked page documents null handling and methodology.

The entry follows the repository's three-file pattern: `README.md`, `research/understand.md`, and `research/manifest.json`.

Validation:

- `bash scripts/lint_readme.sh` (with an explicit relative README path on Windows)
- `python -X utf8 scripts/check_staleness.py`
- `git diff --check`

Verified on 2026-08-11 against the public page, JSON and CSV download endpoints, and source repository.

Disclosure: I maintain AICostBudget.
