### PR TITLE
Add Agent QA to harness efficiency

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Each entry ends with a kind badge: ![tool: MIT](https://img.shields.io/badge/too
 
 ### Harness Efficiency
 
+- [Agent QA](https://github.com/vostride/agent-qa) - A self-improving software-testing harness combining persistent test memory with self-healing web and mobile runs; its primary source publishes no token-use or cost-savings measurement. ![tool: FSL-1.1-ALv2](https://img.shields.io/badge/tool-FSL--1.1--ALv2-blue?style=flat-square) ![last commit](https://img.shields.io/github/last-commit/vostride/agent-qa?style=flat-square&label=)
 - [WOZCODE](https://www.tbench.ai/leaderboard/terminal-bench/2.0) - Claude Code plugin claiming lower token usage and higher task completion, listed sixth on the Terminal-Bench 2.0 leaderboard at 80.2% as an unverified submission. ![tool: none declared](https://img.shields.io/badge/tool-none_declared-blue?style=flat-square)
 
 ### Memory

--- a/research/manifest.json
+++ b/research/manifest.json
@@ -792,6 +792,15 @@
     "super_area": "optimize"
   },
   {
+    "title": "Agent QA",
+    "url": "https://github.com/vostride/agent-qa",
+    "verified_on": "2026-08-16",
+    "stale_after": "2026-11-14",
+    "category": "harness-efficiency",
+    "kind": "tool",
+    "super_area": "optimize"
+  },
+  {
     "title": "AgentDiet - trajectory reduction (\"Reducing Cost of LLM Agents with Trajectory Reduction\")",
     "url": "https://arxiv.org/abs/2509.23586",
     "verified_on": "2026-07-02",


### PR DESCRIPTION
## Summary

Adds Agent QA under Harness Efficiency and records its dated verification metadata in the research manifest.

The wording is intentionally conservative: it describes Agent QA's persistent test memory and self-healing web/mobile testing, while explicitly stating that the primary source publishes no token-use or cost-savings measurement. This makes the evidence boundary visible instead of turning the product's self-improving workflow into an unsupported tokenomics claim.

Project and primary source: https://github.com/vostride/agent-qa

Verified on: 2026-08-16

Disclosure: I am affiliated with the Agent QA project.

## Validation

- `jq empty research/manifest.json`
- `python3 scripts/check_staleness.py` (224 OK, 0 warnings, 0 errors)
- `bash scripts/lint_readme.sh` (passes with no waivers, em dashes, or superlatives)
- `git diff --check`
