### PR TITLE
Add TokenGauge billing audit tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Each entry ends with a kind badge: ![tool: MIT](https://img.shields.io/badge/too
 ### Billing Audit FinOps
 
 - [FinOps for AI - canonical practitioner framework for governing AI/LLM spend](https://www.finops.org/framework/scope/finops-for-ai/) - FinOps for AI is the FinOps Foundation's official practitioner framework for governing AI, GPU, and token spend. ![tool](https://img.shields.io/badge/tool-blue?style=flat-square)
+- [TokenGauge](https://github.com/fablgen-agent/tokengauge) - A browser-local tool that maps aggregate input, cache-read, and output tokens to dated rate cards for nine providers, then reports variance against a user-entered invoice total. ![tool: MIT](https://img.shields.io/badge/tool-MIT-blue?style=flat-square) ![last commit](https://img.shields.io/github/last-commit/fablgen-agent/tokengauge?style=flat-square&label=)
 - [Vaudit - TokenAudit](https://www.vaudit.com/) - Vaudit is an AI-native, independent spend-auditing and recovery platform (San Francisco, founded late 2023). TokenAudit is its LLM invoice-reconciliation product. ![co](https://img.shields.io/badge/co-555?style=flat-square)
 
 ### Budgets Caps

--- a/research/govern.md
+++ b/research/govern.md
@@ -20,6 +20,7 @@
 
 ### Tools
 - [FinOps for AI - canonical practitioner framework for governing AI/LLM spend](https://www.finops.org/framework/scope/finops-for-ai/) - FinOps for AI is the FinOps Foundation's official practitioner framework for governing AI, GPU, and token spend. ![tool](https://img.shields.io/badge/tool-blue?style=flat-square)
+- [TokenGauge](https://github.com/fablgen-agent/tokengauge) - A browser-local tool that maps aggregate input, cache-read, and output tokens to dated rate cards for nine providers, then reports variance against a user-entered invoice total. ![tool: MIT](https://img.shields.io/badge/tool-MIT-blue?style=flat-square) ![last commit](https://img.shields.io/github/last-commit/fablgen-agent/tokengauge?style=flat-square&label=)
 - [Vaudit - TokenAudit](https://www.vaudit.com/) - Vaudit is an AI-native, independent spend-auditing and recovery platform (San Francisco, founded late 2023). TokenAudit is its LLM invoice-reconciliation product. ![co](https://img.shields.io/badge/co-555?style=flat-square)
 
 ## Budgets Caps

--- a/research/manifest.json
+++ b/research/manifest.json
@@ -216,6 +216,15 @@
     "super_area": "govern"
   },
   {
+    "title": "TokenGauge",
+    "url": "https://github.com/fablgen-agent/tokengauge",
+    "verified_on": "2026-08-16",
+    "stale_after": "2026-11-14",
+    "category": "billing-audit-finops",
+    "kind": "oss",
+    "super_area": "govern"
+  },
+  {
     "title": "TrueFoundry (AI Gateway - Budget Limiting)",
     "url": "https://www.truefoundry.com/docs/ai-gateway/budgetlimiting",
     "verified_on": "2026-07-01",


### PR DESCRIPTION
## What changed

- add TokenGauge to the Billing Audit FinOps section in both catalogue surfaces
- add its dated research-manifest record
- label the linked source repository as MIT-licensed

## Why

TokenGauge provides a distinct browser-local audit path: a user enters aggregate input, cache-read, and output tokens, selects one of 52 dated rate cards across nine providers, and can compare the modeled total with a user-entered invoice total. The wording deliberately does not claim automatic invoice ingestion, exact provider-bill enforcement, or proven savings.

Disclosure: I maintain TokenGauge, and this contribution was prepared with AI assistance.

## Verification

- `python3 scripts/check_staleness.py` (224 OK, 0 WARN, 0 ERROR)
- `bash scripts/lint_readme.sh`
- `git diff --check`
- source repository, last-commit badge, and live audit route each returned HTTP 200 on 2026-08-16
