### PR TITLE
Add Weckr under Govern > Unit Economics

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ Each entry ends with a kind badge: ![tool: MIT](https://img.shields.io/badge/too
 ### Unit Economics
 
 - [Paid (paid.ai)](https://paid.ai/) - A monetization platform for AI agents that sets pricing, tracks delivery cost per action and reports margin per customer; distinct from the similarly named Pay-i. ![co](https://img.shields.io/badge/co-555?style=flat-square)
+- [Weckr](https://useweckr.com) - Reports margin per end customer for AI SaaS: an SDK tags each LLM call with the user id, feature and plan, the backend recomputes cost from token counts server-side rather than trusting the client-reported figure, and per-plan spending caps block or downgrade a call before the provider bills for it. Publishes the pricing table it bills from as a live JSON feed. MIT SDKs for TypeScript and Python; hosted backend. ![co](https://img.shields.io/badge/co-555?style=flat-square)
 
 ## Understand
 


### PR DESCRIPTION
Adds one entry to `### Unit Economics` under `## Govern`.

**Disclosure: I built Weckr.** Happy for it to be rejected or reworded; I have tried to keep the one-liner to what is checkable rather than what I would like to be true.

### Why this section

Unit Economics currently has one entry, Paid, which reports margin per customer from the monetization side. Weckr answers the same question from the application side: the SDK attributes each call to a user id, feature and plan at request time, so margin is computed per end customer rather than reconstructed from an invoice. The two are complementary rather than substitutes.

### Primary sources

| Claim in the entry | Source | Verified |
|---|---|---|
| Attributes cost per user and feature, reports margin against plan price | https://useweckr.com/docs | 2026-08-20 |
| Cost recomputed server-side from token counts, client value ignored | https://useweckr.com/docs (Security) | 2026-08-20 |
| Per-plan caps block or downgrade before the call | https://useweckr.com/docs#spending-caps | 2026-08-20 |
| Pricing table published as a live JSON feed | https://useweckr.com/pricing.json (carries a `lastVerified` date per provider) | 2026-08-20 |
| MIT SDKs, TypeScript and Python | https://github.com/Ghiles3232/weckr-sdks (LICENSE) | 2026-08-20 |

The pricing feed is the one I would point at for your evidence standard: it is the actual table the backend bills from, published rather than described, with a per-provider `lastVerified` date. A weekly job diffs it against published provider rates and opens a PR when something moves.

### Badge choice

Used `co`, matching Paid, Revenium and Vantage, since the listed artifact is a hosted service. The SDKs are MIT and stated as such in the one-liner, but they are the client, not the product, so `tool: MIT` seemed misleading.

### Honest status

New, launched May 2026, and I have no paying users yet. I am not claiming adoption anywhere in the entry, and I understand if you would rather wait for evidence of use. Your CONTRIBUTING says entries are judged on checkable evidence rather than popularity, which is why I thought it was worth submitting now rather than later.

### Checks

`bash scripts/lint_readme.sh` passes locally: no em-dashes, no superlatives, one waived marker-format notice that matches the existing baseline. Both links return 200.