### PR TITLE
Add SandBase CLI cost visibility entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Each entry ends with a kind badge: ![tool: MIT](https://img.shields.io/badge/too
 - [LiteLLM](https://github.com/BerriAI/litellm) - An open-source gateway fronting 100+ LLM APIs that computes real per-request dollar cost from a live pricing map, with spend limits. ![tool: MIT](https://img.shields.io/badge/tool-MIT-blue?style=flat-square) ![last commit](https://img.shields.io/github/last-commit/BerriAI/litellm?style=flat-square&label=)
 - [OpenRouter](https://openrouter.ai/docs/guides/routing/provider-selection) - A unified API gateway fronting 400+ models across 70+ providers that auto-routes each request by price, with fallback on outages. ![co](https://img.shields.io/badge/co-555?style=flat-square)
 - [Portkey AI Gateway](https://portkey.ai/docs/product/ai-gateway/virtual-keys/budget-limits) - Routes LLM traffic across providers and enforces hard USD budget limits on virtual keys, auto-expiring a key once its cap is hit. ![co](https://img.shields.io/badge/co-555?style=flat-square)
+- [SandBase CLI](https://github.com/sandbaseai/cli) - An Apache-2.0 CLI and local MCP bridge for 25 AI clients; its inspect tool exposes a model or API's price before execution, and runs lists recent calls with cost breakdowns across a 2,000+ catalog. ![tool: Apache-2.0](https://img.shields.io/badge/tool-Apache--2.0-blue?style=flat-square) ![last commit](https://img.shields.io/github/last-commit/sandbaseai/cli?style=flat-square&label=)
 
 ### Harness Efficiency
 

--- a/research/manifest.json
+++ b/research/manifest.json
@@ -225,6 +225,15 @@
     "super_area": "govern"
   },
   {
+    "title": "SandBase CLI",
+    "url": "https://github.com/sandbaseai/cli",
+    "verified_on": "2026-08-20",
+    "stale_after": "2026-11-18",
+    "category": "gateways-and-proxies",
+    "kind": "oss",
+    "super_area": "optimize"
+  },
+  {
     "title": "TrueFoundry (AI Gateway - Budget Limiting)",
     "url": "https://www.truefoundry.com/docs/ai-gateway/budgetlimiting",
     "verified_on": "2026-07-01",

--- a/research/optimize.md
+++ b/research/optimize.md
@@ -63,6 +63,7 @@
 - [LiteLLM](https://github.com/BerriAI/litellm) - An open-source gateway fronting 100+ LLM APIs that computes real per-request dollar cost from a live pricing map, with spend limits. ![tool: MIT](https://img.shields.io/badge/tool-MIT-blue?style=flat-square) ![last commit](https://img.shields.io/github/last-commit/BerriAI/litellm?style=flat-square&label=)
 - [OpenRouter](https://openrouter.ai/docs/guides/routing/provider-selection) - A unified API gateway fronting 400+ models across 70+ providers that auto-routes each request by price, with fallback on outages. ![co](https://img.shields.io/badge/co-555?style=flat-square)
 - [Portkey AI Gateway](https://portkey.ai/docs/product/ai-gateway/virtual-keys/budget-limits) - Routes LLM traffic across providers and enforces hard USD budget limits on virtual keys, auto-expiring a key once its cap is hit. ![co](https://img.shields.io/badge/co-555?style=flat-square)
+- [SandBase CLI](https://github.com/sandbaseai/cli) - An Apache-2.0 CLI and local MCP bridge for 25 AI clients; its inspect tool exposes a model or API's price before execution, and runs lists recent calls with cost breakdowns across a 2,000+ catalog. ![tool: Apache-2.0](https://img.shields.io/badge/tool-Apache--2.0-blue?style=flat-square) ![last commit](https://img.shields.io/github/last-commit/sandbaseai/cli?style=flat-square&label=)
 
 ## Harness Efficiency
 


### PR DESCRIPTION
## Summary

- add SandBase CLI under Optimize > Gateways and Proxies
- mirror the entry in `research/optimize.md`
- add freshness metadata verified on 2026-08-20

## Evidence

Primary source: https://github.com/sandbaseai/cli#commands

The project README documents 25 supported clients, the 2,000+ catalog, `sandbase_inspect` pricing before execution, and `sandbase_runs` recent calls with cost breakdowns. The repository is Apache-2.0 and active.

## Verification

```text
Staleness: 227 OK, 0 WARN, 0 ERROR
lint_readme: OK
```

## Disclosure

I am contributing on behalf of the SandBase project.