### PR TITLE
Move Energy Carbon under Measure, add Alumet and the Green Software Landscape

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,14 +236,6 @@ Each entry ends with a kind badge: ![tool: MIT](https://img.shields.io/badge/too
 - [Claude Code's 5-hour/weekly usage quotas - Anthropic has stopped publishing exact numbers](https://support.claude.com/en/articles/11049741-what-is-the-max-plan) - Anthropic stopped publishing exact Claude Code usage quotas, describing Max plans only as 5x/20x multipliers of Pro with no absolute numbers.
 - [TrueFoundry (AI Gateway - Budget Limiting)](https://www.truefoundry.com/docs/ai-gateway/budgetlimiting) - TrueFoundry is an enterprise GenAI deployment/gateway company founded by ex-Meta founders. ![co](https://img.shields.io/badge/co-555?style=flat-square)
 
-### Energy Carbon
-
-- [CodeCarbon](https://github.com/mlco2/codecarbon) - An open-source (MIT) library for estimating a workload's energy use and CO2e emissions, and ML's widely-cited carbon baseline. ![tool: MIT](https://img.shields.io/badge/tool-MIT-blue?style=flat-square) ![last commit](https://img.shields.io/github/last-commit/mlco2/codecarbon?style=flat-square&label=)
-- [EcoLogits](https://github.com/mlco2/ecologits) - Estimates the energy and carbon footprint of calling generative-AI APIs: the hosted counterpart to CodeCarbon, which measures your own hardware. ![tool: MPL-2.0](https://img.shields.io/badge/tool-MPL--2.0-blue?style=flat-square) ![last commit](https://img.shields.io/github/last-commit/mlco2/ecologits?style=flat-square&label=)
-- [Epoch AI - how much energy a query uses (the per-token energy anchor)](https://epoch.ai/gradient-updates/how-much-energy-does-chatgpt-use) - Epoch AI built a transparent, first-principles estimate of how much energy one LLM query costs.
-- [Google - measuring the environmental impact of AI inference (provider disclosure)](https://cloud.google.com/blog/products/infrastructure/measuring-the-environmental-impact-of-ai-inference) - Google published a first-party disclosure of the energy, carbon, and water cost of a median Gemini Apps text prompt, authored by Amin Vahdat and Jeff Dean. ![report](https://img.shields.io/badge/report-555?style=flat-square)
-- [ML.ENERGY Leaderboard](https://ml.energy/blog/measurement/energy/diagnosing-inference-energy-consumption-with-the-mlenergy-leaderboard-v30/) - Version 3.0 of this leaderboard measures real GPU inference energy across 46 models x 7 tasks, finding reasoning models use roughly 25x the energy of others. ![bench](https://img.shields.io/badge/bench-555?style=flat-square)
-
 ### Policy Enforcement
 
 - [ActPlane](https://github.com/eunomia-bpf/ActPlane) - An eBPF-based, OS-level policy-enforcement engine for AI-agent harnesses like Claude Code and Codex. ![tool: MIT](https://img.shields.io/badge/tool-MIT-blue?style=flat-square) ![last commit](https://img.shields.io/github/last-commit/eunomia-bpf/ActPlane?style=flat-square&label=)
@@ -379,6 +371,15 @@ Each entry ends with a kind badge: ![tool: MIT](https://img.shields.io/badge/too
 - [TensorZero - cross-vendor token-count divergence ("stop comparing $/M tokens")](https://www.tensorzero.com/blog/stop-comparing-price-per-million-tokens-the-hidden-llm-api-costs/) - The same input can produce 2.65x more tokens on one tokenizer than another's: Claude Opus 4-7 runs 1.57x-2.65x more tokens than GPT-5.4 on the same content.
 - [Vision-token pricing formulas across the big three](https://platform.claude.com/docs/en/build-with-claude/vision) - Anthropic, OpenAI, and Google each convert an image into billed tokens with a different formula, so no single cross-vendor image-cost number exists. (also: [OpenAI](https://developers.openai.com/api/docs/guides/images-vision) · [Google](https://ai.google.dev/gemini-api/docs/image-understanding))
 
+### Energy Carbon
+
+- [Alumet](https://github.com/alumet-dev/alumet) - A Rust measurement framework (EUPL-1.2 or later) that reads hardware energy counters through RAPL, NVML, AMD SMI and Jetson INA plugins, and attributes the energy to processes, cgroups and Kubernetes pods. ![tool: EUPL-1.2-or-later](https://img.shields.io/badge/tool-EUPL--1.2--or--later-blue?style=flat-square) ![last commit](https://img.shields.io/github/last-commit/alumet-dev/alumet?style=flat-square&label=)
+- [CodeCarbon](https://github.com/mlco2/codecarbon) - An open-source (MIT) library for estimating a workload's energy use and CO2e emissions, and ML's widely-cited carbon baseline. ![tool: MIT](https://img.shields.io/badge/tool-MIT-blue?style=flat-square) ![last commit](https://img.shields.io/github/last-commit/mlco2/codecarbon?style=flat-square&label=)
+- [EcoLogits](https://github.com/mlco2/ecologits) - Estimates the energy and carbon footprint of calling generative-AI APIs: the hosted counterpart to CodeCarbon, which measures your own hardware. ![tool: MPL-2.0](https://img.shields.io/badge/tool-MPL--2.0-blue?style=flat-square) ![last commit](https://img.shields.io/github/last-commit/mlco2/ecologits?style=flat-square&label=)
+- [Epoch AI - how much energy a query uses (the per-token energy anchor)](https://epoch.ai/gradient-updates/how-much-energy-does-chatgpt-use) - Epoch AI built a transparent, first-principles estimate of how much energy one LLM query costs.
+- [Google - measuring the environmental impact of AI inference (provider disclosure)](https://cloud.google.com/blog/products/infrastructure/measuring-the-environmental-impact-of-ai-inference) - Google published a first-party disclosure of the energy, carbon, and water cost of a median Gemini Apps text prompt, authored by Amin Vahdat and Jeff Dean. ![report](https://img.shields.io/badge/report-555?style=flat-square)
+- [ML.ENERGY Leaderboard](https://ml.energy/blog/measurement/energy/diagnosing-inference-energy-consumption-with-the-mlenergy-leaderboard-v30/) - Version 3.0 of this leaderboard measures real GPU inference energy across 46 models x 7 tasks, finding reasoning models use roughly 25x the energy of others. ![bench](https://img.shields.io/badge/bench-555?style=flat-square)
+
 ### Harness Overhead
 
 - [Claude Code system prompts (Piebald extraction)](https://github.com/Piebald-AI/claude-code-system-prompts) - Piebald AI extracts Claude Code's full compiled prompt payload per release: 515 prompt strings and 27 tool descriptions at v2.1.212, each priced in tokens. ![data](https://img.shields.io/badge/data-555?style=flat-square) ![last commit](https://img.shields.io/github/last-commit/Piebald-AI/claude-code-system-prompts?style=flat-square&label=)
@@ -426,6 +427,7 @@ Runnable, validated Claude Code and Codex configurations and skills for token-ef
 - [Awesome-LLMOps](https://github.com/tensorchord/Awesome-LLMOps) - Tools and platforms for operating LLMs in production.
 - [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers) - A collection of Model Context Protocol servers.
 - [awesome-production-machine-learning](https://github.com/EthicalML/awesome-production-machine-learning) - Open-source libraries to deploy, monitor, version, and scale machine learning.
+- [Green Software Landscape](https://landscape.bundesverband-green-software.de/) - A CC0 catalog of 130 green-software tools maintained by Bundesverband Green Software e.V., with AI training and inference energy subcategories.
 
 ## Footnotes
 

--- a/research/govern.md
+++ b/research/govern.md
@@ -30,19 +30,6 @@
 ### Reading
 - [Claude Code's 5-hour/weekly usage quotas - Anthropic has stopped publishing exact numbers](https://support.claude.com/en/articles/11049741-what-is-the-max-plan) - Anthropic stopped publishing exact Claude Code usage quotas, describing Max plans only as 5x/20x multipliers of Pro with no absolute numbers.
 
-## Energy Carbon
-
-### Tools
-- [CodeCarbon](https://github.com/mlco2/codecarbon) - An open-source (MIT) library for estimating a workload's energy use and CO2e emissions, and ML's widely-cited carbon baseline. ![tool: MIT](https://img.shields.io/badge/tool-MIT-blue?style=flat-square) ![last commit](https://img.shields.io/github/last-commit/mlco2/codecarbon?style=flat-square&label=)
-- [EcoLogits](https://github.com/mlco2/ecologits) - Estimates the energy and carbon footprint of calling generative-AI APIs: the hosted counterpart to CodeCarbon, which measures your own hardware. ![tool: MPL-2.0](https://img.shields.io/badge/tool-MPL--2.0-blue?style=flat-square) ![last commit](https://img.shields.io/github/last-commit/mlco2/ecologits?style=flat-square&label=)
-
-### Research & Benchmarks
-- [Google - measuring the environmental impact of AI inference (provider disclosure)](https://cloud.google.com/blog/products/infrastructure/measuring-the-environmental-impact-of-ai-inference) - Google published a first-party disclosure of the energy, carbon, and water cost of a median Gemini Apps text prompt, authored by Amin Vahdat and Jeff Dean. ![report](https://img.shields.io/badge/report-555?style=flat-square)
-- [ML.ENERGY Leaderboard](https://ml.energy/blog/measurement/energy/diagnosing-inference-energy-consumption-with-the-mlenergy-leaderboard-v30/) - Version 3.0 of this leaderboard measures real GPU inference energy across 46 models x 7 tasks, finding reasoning models use roughly 25x the energy of others. ![bench](https://img.shields.io/badge/bench-555?style=flat-square)
-
-### Reading
-- [Epoch AI - how much energy a query uses (the per-token energy anchor)](https://epoch.ai/gradient-updates/how-much-energy-does-chatgpt-use) - Epoch AI built a transparent, first-principles estimate of how much energy one LLM query costs.
-
 ## Policy Enforcement
 
 ### Tools

--- a/research/manifest.json
+++ b/research/manifest.json
@@ -63,15 +63,6 @@
     "super_area": "govern"
   },
   {
-    "title": "CodeCarbon",
-    "url": "https://github.com/mlco2/codecarbon",
-    "verified_on": "2026-07-01",
-    "stale_after": "2026-10-01",
-    "category": "energy-carbon",
-    "kind": "oss",
-    "super_area": "govern"
-  },
-  {
     "title": "Denial-of-Wallet / token-exhaustion attacks",
     "url": "https://arxiv.org/abs/2601.10955",
     "verified_on": "2026-07-01",
@@ -81,39 +72,12 @@
     "super_area": "govern"
   },
   {
-    "title": "EcoLogits",
-    "url": "https://github.com/mlco2/ecologits",
-    "verified_on": "2026-07-02",
-    "stale_after": "2026-10-02",
-    "category": "energy-carbon",
-    "kind": "oss",
-    "super_area": "govern"
-  },
-  {
-    "title": "Epoch AI - how much energy a query uses (the per-token energy anchor)",
-    "url": "https://epoch.ai/gradient-updates/how-much-energy-does-chatgpt-use",
-    "verified_on": "2026-07-02",
-    "stale_after": "2026-10-02",
-    "category": "energy-carbon",
-    "kind": "article",
-    "super_area": "govern"
-  },
-  {
     "title": "FinOps for AI - canonical practitioner framework for governing AI/LLM spend",
     "url": "https://www.finops.org/framework/scope/finops-for-ai/",
     "verified_on": "2026-07-01",
     "stale_after": "2026-10-01",
     "category": "billing-audit-finops",
     "kind": "framework",
-    "super_area": "govern"
-  },
-  {
-    "title": "Google - measuring the environmental impact of AI inference (provider disclosure)",
-    "url": "https://cloud.google.com/blog/products/infrastructure/measuring-the-environmental-impact-of-ai-inference",
-    "verified_on": "2026-07-02",
-    "stale_after": "2026-10-02",
-    "category": "energy-carbon",
-    "kind": "report",
     "super_area": "govern"
   },
   {
@@ -159,15 +123,6 @@
     "stale_after": "2026-10-03",
     "category": "policy-enforcement",
     "kind": "oss",
-    "super_area": "govern"
-  },
-  {
-    "title": "ML.ENERGY Leaderboard",
-    "url": "https://ml.energy/blog/measurement/energy/diagnosing-inference-energy-consumption-with-the-mlenergy-leaderboard-v30/",
-    "verified_on": "2026-07-02",
-    "stale_after": "2026-10-02",
-    "category": "energy-carbon",
-    "kind": "benchmark",
     "super_area": "govern"
   },
   {
@@ -261,6 +216,15 @@
     "super_area": "govern"
   },
   {
+    "title": "Alumet",
+    "url": "https://github.com/alumet-dev/alumet",
+    "verified_on": "2026-09-05",
+    "stale_after": "2026-12-04",
+    "category": "energy-carbon",
+    "kind": "oss",
+    "super_area": "measure"
+  },
+  {
     "title": "Anthropic bill anatomy - the whole-bill line-item taxonomy",
     "url": "https://platform.claude.com/docs/en/about-claude/pricing#code-execution-tool",
     "verified_on": "2026-07-02",
@@ -294,6 +258,15 @@
     "stale_after": "2026-10-01",
     "category": "benchmarks-evals",
     "kind": "benchmark",
+    "super_area": "measure"
+  },
+  {
+    "title": "CodeCarbon",
+    "url": "https://github.com/mlco2/codecarbon",
+    "verified_on": "2026-07-01",
+    "stale_after": "2026-10-01",
+    "category": "energy-carbon",
+    "kind": "oss",
     "super_area": "measure"
   },
   {
@@ -342,6 +315,24 @@
     "super_area": "measure"
   },
   {
+    "title": "EcoLogits",
+    "url": "https://github.com/mlco2/ecologits",
+    "verified_on": "2026-07-02",
+    "stale_after": "2026-10-02",
+    "category": "energy-carbon",
+    "kind": "oss",
+    "super_area": "measure"
+  },
+  {
+    "title": "Epoch AI - how much energy a query uses (the per-token energy anchor)",
+    "url": "https://epoch.ai/gradient-updates/how-much-energy-does-chatgpt-use",
+    "verified_on": "2026-07-02",
+    "stale_after": "2026-10-02",
+    "category": "energy-carbon",
+    "kind": "article",
+    "super_area": "measure"
+  },
+  {
     "title": "Faros AI - \"Token Intelligence\" / Token Attribution Ledger",
     "url": "https://www.faros.ai/blog/token-intelligence-for-ai-engineering",
     "verified_on": "2026-07-02",
@@ -375,6 +366,15 @@
     "stale_after": "2026-10-20",
     "category": "cache-accounting",
     "kind": "article",
+    "super_area": "measure"
+  },
+  {
+    "title": "Google - measuring the environmental impact of AI inference (provider disclosure)",
+    "url": "https://cloud.google.com/blog/products/infrastructure/measuring-the-environmental-impact-of-ai-inference",
+    "verified_on": "2026-07-02",
+    "stale_after": "2026-10-02",
+    "category": "energy-carbon",
+    "kind": "report",
     "super_area": "measure"
   },
   {
@@ -428,6 +428,15 @@
     "verified_on": "2026-07-21",
     "stale_after": "2026-10-21",
     "category": "benchmarks-evals",
+    "kind": "benchmark",
+    "super_area": "measure"
+  },
+  {
+    "title": "ML.ENERGY Leaderboard",
+    "url": "https://ml.energy/blog/measurement/energy/diagnosing-inference-energy-consumption-with-the-mlenergy-leaderboard-v30/",
+    "verified_on": "2026-07-02",
+    "stale_after": "2026-10-02",
+    "category": "energy-carbon",
     "kind": "benchmark",
     "super_area": "measure"
   },

--- a/research/measure.md
+++ b/research/measure.md
@@ -34,6 +34,20 @@
 - [TensorZero - cross-vendor token-count divergence ("stop comparing $/M tokens")](https://www.tensorzero.com/blog/stop-comparing-price-per-million-tokens-the-hidden-llm-api-costs/) - The same input can produce 2.65x more tokens on one tokenizer than another's: Claude Opus 4-7 runs 1.57x-2.65x more tokens than GPT-5.4 on the same content.
 - [Vision-token pricing formulas across the big three](https://platform.claude.com/docs/en/build-with-claude/vision) - Anthropic, OpenAI, and Google each convert an image into billed tokens with a different formula, so no single cross-vendor image-cost number exists. (also: [OpenAI](https://developers.openai.com/api/docs/guides/images-vision) · [Google](https://ai.google.dev/gemini-api/docs/image-understanding))
 
+## Energy Carbon
+
+### Tools
+- [Alumet](https://github.com/alumet-dev/alumet) - A Rust measurement framework (EUPL-1.2 or later) that reads hardware energy counters through RAPL, NVML, AMD SMI and Jetson INA plugins, and attributes the energy to processes, cgroups and Kubernetes pods. ![tool: EUPL-1.2-or-later](https://img.shields.io/badge/tool-EUPL--1.2--or--later-blue?style=flat-square) ![last commit](https://img.shields.io/github/last-commit/alumet-dev/alumet?style=flat-square&label=)
+- [CodeCarbon](https://github.com/mlco2/codecarbon) - An open-source (MIT) library for estimating a workload's energy use and CO2e emissions, and ML's widely-cited carbon baseline. ![tool: MIT](https://img.shields.io/badge/tool-MIT-blue?style=flat-square) ![last commit](https://img.shields.io/github/last-commit/mlco2/codecarbon?style=flat-square&label=)
+- [EcoLogits](https://github.com/mlco2/ecologits) - Estimates the energy and carbon footprint of calling generative-AI APIs: the hosted counterpart to CodeCarbon, which measures your own hardware. ![tool: MPL-2.0](https://img.shields.io/badge/tool-MPL--2.0-blue?style=flat-square) ![last commit](https://img.shields.io/github/last-commit/mlco2/ecologits?style=flat-square&label=)
+
+### Research & Benchmarks
+- [Google - measuring the environmental impact of AI inference (provider disclosure)](https://cloud.google.com/blog/products/infrastructure/measuring-the-environmental-impact-of-ai-inference) - Google published a first-party disclosure of the energy, carbon, and water cost of a median Gemini Apps text prompt, authored by Amin Vahdat and Jeff Dean. ![report](https://img.shields.io/badge/report-555?style=flat-square)
+- [ML.ENERGY Leaderboard](https://ml.energy/blog/measurement/energy/diagnosing-inference-energy-consumption-with-the-mlenergy-leaderboard-v30/) - Version 3.0 of this leaderboard measures real GPU inference energy across 46 models x 7 tasks, finding reasoning models use roughly 25x the energy of others. ![bench](https://img.shields.io/badge/bench-555?style=flat-square)
+
+### Reading
+- [Epoch AI - how much energy a query uses (the per-token energy anchor)](https://epoch.ai/gradient-updates/how-much-energy-does-chatgpt-use) - Epoch AI built a transparent, first-principles estimate of how much energy one LLM query costs.
+
 ## Harness Overhead
 
 ### Research & Benchmarks


### PR DESCRIPTION
- Energy Carbon section moves from Govern to Measure
- Alumet added to Energy Carbon tools
- Green Software Landscape added to Related lists

Suggested by a community member.