### PR TITLE
Add OrcaReplay under Monitor → Tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Each entry ends with a kind badge: ![tool: MIT](https://img.shields.io/badge/too
 - [claude-tap](https://github.com/liaohch3/claude-tap) - A local trace viewer intercepting API traffic from 14+ coding agents, showing per-request token breakdowns: input, output, cache read, cache creation. ![tool: MIT](https://img.shields.io/badge/tool-MIT-blue?style=flat-square) ![last commit](https://img.shields.io/github/last-commit/liaohch3/claude-tap?style=flat-square&label=)
 - [LangSmith - Cost Tracking](https://docs.langchain.com/langsmith/cost-tracking) - LangSmith is LangChain's commercial LLM/agent observability SaaS. ![co](https://img.shields.io/badge/co-555?style=flat-square)
 - [Opik](https://github.com/comet-ml/opik) - Comet's open-source (Apache-2.0) LLM observability platform, with per-span USD cost estimated from token usage. ![tool: Apache-2.0](https://img.shields.io/badge/tool-Apache--2.0-blue?style=flat-square) ![last commit](https://img.shields.io/github/last-commit/comet-ml/opik?style=flat-square&label=)
+- [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) - Records coding-agent runs below the harness (no SDK) with per-exchange input/output token counts taken from the provider response, and replays the same run offline so a re-run costs nothing. ![tool: Apache-2.0](https://img.shields.io/badge/tool-Apache--2.0-blue?style=flat-square) ![last commit](https://img.shields.io/github/last-commit/Continuum-AI-Corp/OrcaReplay?style=flat-square&label=)
 
 ## Optimize
 


### PR DESCRIPTION
Adds [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) — one line, in the section this fits.

**Disclosure: I work on it.** Apache-2.0, free, no paid tier, no account.

## What it is

A record/replay debugger for coding agents. It captures a run **below the harness** — a base-URL variable moved for that process, or TLS terminated for one named host — so the agent itself is unmodified and needs no SDK, exporter or plugin. The trace keeps the verbatim request and response bytes, which is what makes the next part possible: the run re-executes with the network off (`egress=blocked`), served the recorded exchanges back.

```bash
npm i -g orcareplay
orca record claude            # or codex, goose, hermes, opencode, qwen, cursor, grok, openclaw
orca replay last              # reproduce it, network off
orca compare last --models a,b,c --verify "npm test"
```

## Why it is not the same thing as the tracing tools already listed

The OpenTelemetry path — which is what Langfuse, Phoenix and the rest consume — does not capture message content by default, and even with `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true` what lands is span attributes: a normalised *view* of the call, not the bytes on the wire. You cannot serve a span back to an SDK as an HTTP response. It also assumes the agent can be instrumented, and the agents most people actually run — Claude Code, Codex CLI, goose — are binaries you invoke, not libraries you import.

So this sits beside those tools rather than replacing them: they are the system of record for a fleet, this is a debugger you point at one run.

## Verified, not asserted

Two harnesses have been driven end to end against the real thing, and each broke something that got fixed:

- **Claude Code** — [walked through against a real bug fix](https://github.com/Continuum-AI-Corp/OrcaReplay/blob/main/docs/validation.md).
- **goose** 1.49.0 — `1 failed` → agent fixes it → `1 passed`, then strict offline replay `reused=8/8 exact=8 divergences=0`, three runs in a row.
- **Hermes** v0.21.0 — recorded and replayed offline, `reused=1/1 egress=blocked`.

Every adapter has a fixture recording the exact environment variables it sets, so a harness that renames one turns a check red instead of producing an empty trace.

## Details

- Apache-2.0 · TypeScript · Linux/macOS/Windows · `npm i -g orcareplay`
- Ships an MCP server (`orca mcp`, protocol `2025-06-18`) and an Agent Skill
- Listed in the official MCP Registry
- ~1,700 tests and a trace-format conformance suite

Happy to reword, shorten, or move it to a different section — say which and I will push the change.
